### PR TITLE
Revert " Added dh_testers to requirements"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-dh_testers
 gender-guesser==0.4.0
 ipython
 jupyter

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ setuptools.setup(
     author_email="cuthbert@mit.edu",
     description="Descriptions of Gender in Writing",
     install_requires=REQUIRED_PACKAGES,
-    dependency_links= [
-        'https://github.com/dhmit/dh_testers.git#egg=dh_testers'
-    ],
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     url="https://github.com/dhmit/gender_novels",


### PR DESCRIPTION
I seem to have been misled by a weirdly configured PATH into believing that installing dh_testers from github worked -> reverting to earlier commit until I can fix it.