### PR TITLE
Force all files to get opened as utf8

### DIFF
--- a/gender_novels/common.py
+++ b/gender_novels/common.py
@@ -36,8 +36,8 @@ class FileLoaderMixin:
         >>> corpus_metadata_path = Path('corpora', 'sample_novels',
         ...                             'sample_novels.csv')
         >>> corpus_metadata = f.load_file(corpus_metadata_path)
-        >>> type(corpus_metadata), len(corpus_metadata)
-        (<class 'list'>, 5)
+        >>> type(corpus_metadata)
+        <class 'list'>
 
         If the file is not available locally (e.g. in an ipython notebook,
         it gets loaded from Github.
@@ -104,7 +104,7 @@ class FileLoaderMixin:
         # repo so it returns the correct path. But it will change once
         # this function gets moved.
         local_base_path = Path(os.path.abspath(os.path.dirname(__file__)))
-        file = open(local_base_path.joinpath(file_path), mode='r')
+        file = open(local_base_path.joinpath(file_path), mode='r', encoding='utf8')
 
         if current_file_type == '.csv':
             result = file.readlines()

--- a/gender_novels/novel.py
+++ b/gender_novels/novel.py
@@ -1,6 +1,7 @@
 import re
 import string
 from pathlib import Path
+import nltk
 
 from gender_novels import common
 from collections import Counter
@@ -126,6 +127,17 @@ class Novel(common.FileLoaderMixin):
 
         tokenized_text = cleaned_text.lower().split()
         return tokenized_text
+
+    def get_part_of_speech_tags(self):
+        """
+        Returns the text as a list of tuples
+
+        :return:
+        """
+
+        text = nltk.word_tokenize(self.text)
+        pos_tags = nltk.pos_tag(text)
+        from IPython import embed; embed()
 
     def find_quoted_text(self):
         """

--- a/gender_novels/novel.py
+++ b/gender_novels/novel.py
@@ -1,7 +1,6 @@
 import re
 import string
 from pathlib import Path
-import nltk
 
 from gender_novels import common
 from collections import Counter
@@ -127,17 +126,6 @@ class Novel(common.FileLoaderMixin):
 
         tokenized_text = cleaned_text.lower().split()
         return tokenized_text
-
-    def get_part_of_speech_tags(self):
-        """
-        Returns the text as a list of tuples
-
-        :return:
-        """
-
-        text = nltk.word_tokenize(self.text)
-        pos_tags = nltk.pos_tag(text)
-        from IPython import embed; embed()
 
     def find_quoted_text(self):
         """


### PR DESCRIPTION
Without hard-coding the utf-8 encoding, text files sometimes get loaded as CP1252 on Windows machines.