### PR TITLE
__str__ for Novel class

### DIFF
--- a/gender_novels/novel.py
+++ b/gender_novels/novel.py
@@ -12,8 +12,6 @@ class Novel(common.FileLoaderMixin):
     """ The Novel class loads and holds the full text and
     metadata (author, title, publication date) of a novel
 
-    TODO: write __str__ for novels
-
     >>> from gender_novels import novel
     >>> novel_metadata = {'author': 'Austen, Jane', 'title': 'Persuasion',
     ...                   'corpus_name': 'sample_novels', 'date': '1818',
@@ -74,6 +72,24 @@ class Novel(common.FileLoaderMixin):
                     f'The novel filename ({self.filename}) should end in .txt . Full metadata: '
                     f'{novel_metadata_dict}.')
             self.text = self._load_novel_text()
+
+    def __str__(self):
+        """
+        Overrides python print method for user-defined objects for Novel class
+        Returns the filename without the extension - author and title word
+        :return: string
+
+        >>>from gender_novels import novel
+        >>> novel_metadata = {'author': 'Austen, Jane', 'title': 'Persuasion',
+        ...                   'corpus_name': 'sample_novels', 'date': '1818',
+        ...                   'filename': 'austen_persuasion.txt'}
+        >>> austen = novel.Novel(novel_metadata)
+        >>> n = str(austen)
+        >>>n
+        austen_persuasion
+        """
+        name = self.filename[0:len(self.filename)-4]
+        return name
 
 
     def _load_novel_text(self):


### PR DESCRIPTION
This method overrides the python built in print method for our user-defined Novel class.  When str() or print() is called on Novel, it returns the name of the file but without the extension (author underscore title word).