### PR TITLE
Reverted indicated lower bound of year range to 1770

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gender_novels
-Analysis of Gender and Gender Relations in English-Language Novels 1776-1922
+Analysis of Gender and Gender Relations in English-Language Novels 1770-1922
 
 A project of the MIT/SHASS Programs in Digital Humanities (specifically the Digital Humanities Lab) 
 funded by the Mellon Foundation.

--- a/gender_novels/corpora/Copyright Info/copyright_info.md
+++ b/gender_novels/corpora/Copyright Info/copyright_info.md
@@ -29,11 +29,11 @@ biggest rule.*)
 
 * Because any book first published before 1923 is in the Public Domain, any book which is still 
 copyrighted cannot have been published before 1923. Because our study only examines books written
- from 1776-1922, **any book that is still copyrighted is not within our time period of interest and 
+ from 1770-1922, **any book that is still copyrighted is not within our time period of interest and 
  not the subject of this study.** However, do note the following:
 
 * Not all books in the Public Domain were first published 
-between 1776-1922. Books can enter the Public Domain other ways, eg if  a book's author 
+between 1770-1922. Books can enter the Public Domain other ways, eg if  a book's author 
 voluntarily enters it to the Public Domain. **There are books in the Public Domain which are not 
 the subject of our study.**
 

--- a/gender_novels/deployment/static/markdowns/copyright_info.md
+++ b/gender_novels/deployment/static/markdowns/copyright_info.md
@@ -29,11 +29,11 @@ biggest rule.*)
 
 * Because any book first published before 1923 is in the Public Domain, any book which is still 
 copyrighted cannot have been published before 1923. Because our study only examines books written
- from 1776-1922, **any book that is still copyrighted is not within our time period of interest and 
+ from 1770-1922, **any book that is still copyrighted is not within our time period of interest and 
  not the subject of this study.** However, do note the following:
 
 * Not all books in the Public Domain were first published 
-between 1776-1922. Books can enter the Public Domain other ways, eg if  a book's author 
+between 1770-1922. Books can enter the Public Domain other ways, eg if  a book's author 
 voluntarily enters it to the Public Domain. **There are books in the Public Domain which are not 
 the subject of our study.**
 


### PR DESCRIPTION
Our original year bound was 1770-1922; midway through the project we shifted bounds to 1776-1922, but it seems this shift was not completely updated. The corpus and other analyses were generated with the original bound of 1770, and it is impractical to regenerate the corpus or delete the removed years, so we are reverting to the original bound of 1770.