### PR TITLE
Fix Metadata Downloading

### DIFF
--- a/gender_novels/corpus.py
+++ b/gender_novels/corpus.py
@@ -7,6 +7,7 @@ from collections import Counter
 
 from gender_novels import common
 from gender_novels.novel import Novel
+import requests
 
 
 class Corpus(common.FileLoaderMixin):
@@ -88,6 +89,11 @@ class Corpus(common.FileLoaderMixin):
                 os.mkdir(gutenberg_path)
             zipf.extractall(gutenberg_path)
             os.remove('gutenberg_corpus.zip')
+            metadata_url = r'https://raw.githubusercontent.com/dhmit/gender_novels/master' \
+                        r'/gender_novels/corpora/gutenberg/gutenberg.csv'
+            r = requests.get(metadata_url, allow_redirects=True)
+            with open(gutenberg_path/Path('gutenberg.csv'), 'wb') as metadata_file:
+                metadata_file.write(r.content)
 
             # check that we now have 4000 novels available
             try:

--- a/gender_novels/novel.py
+++ b/gender_novels/novel.py
@@ -54,7 +54,7 @@ class Novel(common.FileLoaderMixin):
 
         # check that the author starts with a capital letter
         # TODO: Currently deactivated because gutenberg authors are lists
-        # TODO: reimplement with lists in mind.
+        # TODO: reimplement with lists in mind.  Note: there are a few novels with no author
         # if not novel_metadata_dict['author'][0].isupper():
         #    raise ValueError('The last name of the author should be upper case.',
         #                     f'{novel_metadata_dict["author"]} is likely incorrect in',


### PR DESCRIPTION
When downloading the corpus, it now downloads the newer version of the metadata from the repo instead of the old version with errors.  